### PR TITLE
Evalutator tools

### DIFF
--- a/index.md
+++ b/index.md
@@ -57,8 +57,8 @@ layout: default
 | [NTRU](https://github.com/prokls/ntrust-native) | Rust  | Lukas Prokop |
 | [SABER](https://github.com/lkiem/rusty_saber) | Rust  | Lukas Prokop & Lukas Kiem |
 
-## Evaluation tools
-- [LWE estimator (Albrecht et. al.)](https://lwe-estimator.readthedocs.io/)
+## Security estimation tools
+- [Lattice estimator](https://github.com/malb/lattice-estimator/)
 - [Leaky LWE estimator (Dachman-Soled et. al.)](https://github.com/lducas/leaky-LWE-Estimator)
 
 <!--


### PR DESCRIPTION
1. evaluator tools -> securityu estimation tools
2. lattice estimator supersedes lwe estimator
3. I prefer not to have "Albrecht et al.", it aims to be a community project.